### PR TITLE
Add a distinction between EOF and no match

### DIFF
--- a/klang/src/main/kotlin/cz/j_jzk/klang/lex/Lexer.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/lex/Lexer.kt
@@ -3,6 +3,7 @@ package cz.j_jzk.klang.lex
 import cz.j_jzk.klang.lex.re.fa.NFA
 import cz.j_jzk.klang.lex.re.MultipleMatcher
 import cz.j_jzk.klang.util.listiterator.previousString
+import java.io.EOFException
 
 /**
  * The class that does the lexing. You probably don't want to create this
@@ -24,13 +25,14 @@ class Lexer<T>(private val tokenDefs: LinkedHashMap<NFA, T>, private val ignored
 
 	/**
 	 * Match a token from an input.
-	 * Returns `null` on EOF or no match.
+	 * Returns `null` on no match.
+	 * Throws an `EOFException` on EOF.
 	 */
 	fun nextToken(input: ListIterator<Char>): Token<T>? {
-		val longestMatch = chooseMatch(matcher.nextMatch(input))
+		if (!input.hasNext())
+			throw EOFException()
 
-		if (longestMatch == null)
-			return null
+		val longestMatch = chooseMatch(matcher.nextMatch(input)) ?: return null
 
 		if (longestMatch.key in ignored)
 			return nextToken(input)

--- a/klang/src/test/kotlin/cz/j_jzk/klang/lex/LexerTest.kt
+++ b/klang/src/test/kotlin/cz/j_jzk/klang/lex/LexerTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.Ignore
 import cz.j_jzk.klang.testutils.re
 import cz.j_jzk.klang.testutils.iter
 import cz.j_jzk.klang.testutils.testLex
+import java.io.EOFException
+import kotlin.test.assertFailsWith
 
 /*
  * Correct matching doesn't need to be tested extensively because it is already
@@ -26,16 +28,25 @@ class LexerTest {
 		assertEquals(Token("int", "123"), lexer.nextToken(input))
 	}
 
-	@Ignore @Test fun testNoMatch() {
-		// test if the lexer throws an error of some sort on no match
-		// (maybe don't check this in the lexer, but instead use some sort of error token)
-		TODO()
+	@Test fun testNoMatch() {
+		val input = iter("xyz")
+		assertEquals(null, lexer.nextToken(input))
 	}
 
 	@Test fun testEndOfInput() {
 		val input = iter("if")
 		lexer.nextToken(input)
 
+		assertFailsWith(EOFException::class) { lexer.nextToken(input) }
+	}
+
+	@Test fun testNoMatchWithIgnored() {
+		val lexer = Lexer<String>(
+			linkedMapOf(re("\\d+") to "INT"),
+			listOf(re(" "))
+		)
+
+		val input = iter("   a")
 		assertEquals(null, lexer.nextToken(input))
 	}
 


### PR DESCRIPTION
Will have to think through how to add an API for this in the builder.

I was thinking of something like this:
```kotlin
lexer {
    // token definitions
    onNoMatch {
        // some sort of error report
        // the character would be automatically skipped
    }
}
```

However, this way, the builder would need to return a wrapper class arould the `Lexer` which would handle calling the onNoMatch function, and that isn't in the scope of this pull request.