### PR TITLE
Add a wrapper around the Lexer class

### DIFF
--- a/klang/src/main/kotlin/cz/j_jzk/klang/lex/Lexer.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/lex/Lexer.kt
@@ -6,8 +6,9 @@ import cz.j_jzk.klang.util.listiterator.previousString
 import java.io.EOFException
 
 /**
- * The class that does the lexing. You probably don't want to create this
- * object directly, but instead use a builder (`cz.j_jzk.klang.lex.api.lexer()`)
+ * The class that does the lexing. You probably don't want to create or use this
+ * object directly, but instead use a builder (`cz.j_jzk.klang.lex.api.lexer()`),
+ * which returns a LexerWrapper.
  * 
  * The type parameter `T` is the token type identifier. Enums are the most
  * suitable to this, but you may as well use anything you want.

--- a/klang/src/main/kotlin/cz/j_jzk/klang/lex/Lexer.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/lex/Lexer.kt
@@ -36,7 +36,10 @@ class Lexer<T>(private val tokenDefs: LinkedHashMap<NFA, T>, private val ignored
 		val longestMatch = chooseMatch(matcher.nextMatch(input)) ?: return null
 
 		if (longestMatch.key in ignored)
-			return nextToken(input)
+			return if (input.hasNext())
+				nextToken(input)
+			else
+				null
 
 		return Token(
 			tokenDefs[longestMatch.key]!!,

--- a/klang/src/main/kotlin/cz/j_jzk/klang/lex/LexerWrapper.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/lex/LexerWrapper.kt
@@ -19,8 +19,29 @@ class LexerWrapper<T>(val lexer: Lexer<T>, private val onNoMatch: (Char) -> Unit
 		return match
 	}
 
-	fun iterator(input: ListIterator<Char>) = object : Iterator<Token<T>?> {
-		override fun hasNext() = input.hasNext()
-		override fun next() = nextMatch(input)
+	fun iterator(input: ListIterator<Char>) = LexerIterator(input)
+
+	inner class LexerIterator(private val input: ListIterator<Char>): Iterator<Token<T>> {
+		/* We actually have to load tokens ahead of time to know if there are any
+		 * or if it's just invalid characters and EOF. */
+		private var nextValue: Token<T>? = null
+		init {
+			loadNextValue()
+		}
+
+		private fun loadNextValue() {
+			nextValue =
+				if (input.hasNext())
+					nextMatch(input)
+				else
+					null
+		}
+
+		override fun hasNext() = nextValue != null
+		override fun next() =
+			nextValue?.let {
+				loadNextValue()
+				it
+			} ?: throw NoSuchElementException()
 	}
 }

--- a/klang/src/main/kotlin/cz/j_jzk/klang/lex/LexerWrapper.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/lex/LexerWrapper.kt
@@ -1,0 +1,26 @@
+package cz.j_jzk.klang.lex
+
+class LexerWrapper<T>(val lexer: Lexer<T>, private val onNoMatch: (Char) -> Unit) {
+	/**
+	 * Matches one token and handles events (onNoMatch).
+	 * When there is no match, it automatically returns the next one, but can
+	 * still return null when there are no matches up to the end of input.
+	 */
+	private fun nextMatch(input: ListIterator<Char>): Token<T>? {
+		val match = lexer.nextToken(input)
+		if (match == null) {
+			onNoMatch(input.next())
+			return if (input.hasNext())
+				nextMatch(input)
+			else
+				null
+		}
+
+		return match
+	}
+
+	fun iterator(input: ListIterator<Char>) = object : Iterator<Token<T>?> {
+		override fun hasNext() = input.hasNext()
+		override fun next() = nextMatch(input)
+	}
+}

--- a/klang/src/main/kotlin/cz/j_jzk/klang/lex/LexerWrapper.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/lex/LexerWrapper.kt
@@ -8,12 +8,17 @@ class LexerWrapper<T>(val lexer: Lexer<T>, private val onNoMatch: (Char) -> Unit
 	 */
 	private fun nextMatch(input: ListIterator<Char>): Token<T>? {
 		val match = lexer.nextToken(input)
+		// TODO untangle this mess
 		if (match == null) {
-			onNoMatch(input.next())
-			return if (input.hasNext())
-				nextMatch(input)
-			else
-				null
+			if (input.hasNext()) {
+				onNoMatch(input.next())
+				return if (input.hasNext())
+					nextMatch(input)
+				else
+					null
+			} else {
+				return null
+			}
 		}
 
 		return match

--- a/klang/src/main/kotlin/cz/j_jzk/klang/util/listiterator/listIterator.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/util/listiterator/listIterator.kt
@@ -15,3 +15,9 @@ fun ListIterator<Char>.previousString(len: Int): String {
 
 	return builder.toString()
 }
+
+fun <T> ListIterator<T>.nextOrNull() =
+	if (hasNext())
+		next()
+	else
+		null

--- a/klang/src/test/kotlin/cz/j_jzk/klang/lex/LexerWrapperTest.kt
+++ b/klang/src/test/kotlin/cz/j_jzk/klang/lex/LexerWrapperTest.kt
@@ -14,7 +14,19 @@ class LexerWrapperTest {
 
 	@Test fun testBasicIterator() {
 		testIterator(
-			" 1  23 4 ",
+			" 1  23 4",
+			listOf(
+				Token("INT", "1"),
+				Token("INT", "23"),
+				Token("INT", "4"),
+			),
+			0
+		)
+	}
+
+	@Test fun testIgnoredCharacterAtEndOfInput() {
+		testIterator(
+			" 1  23 4  ",
 			listOf(
 				Token("INT", "1"),
 				Token("INT", "23"),

--- a/klang/src/test/kotlin/cz/j_jzk/klang/lex/LexerWrapperTest.kt
+++ b/klang/src/test/kotlin/cz/j_jzk/klang/lex/LexerWrapperTest.kt
@@ -1,0 +1,63 @@
+package cz.j_jzk.klang.lex
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import cz.j_jzk.klang.lex.api.lexer
+import cz.j_jzk.klang.testutils.iter
+
+class LexerWrapperTest {
+	private val lexer = lexer<String> {
+		"INT" to "\\d+"
+		ignore("\\s")
+	}.getLexer()
+
+	@Test fun testBasicIterator() {
+		testIterator(
+			" 1  23 4 ",
+			listOf(
+				Token("INT", "1"),
+				Token("INT", "23"),
+				Token("INT", "4"),
+			),
+			0
+		)
+	}
+
+	@Test fun testOnNoMatch() {
+		testIterator(
+			" 1  23x 4 x",
+			listOf(
+				Token("INT", "1"),
+				Token("INT", "23"),
+				Token("INT", "4"),
+			),
+			2
+		)
+	}
+
+	@Test fun testNoMatch() {
+		testIterator("abc", emptyList(), 3)
+	}
+
+	private fun testIterator(input: String, expectedTokens: List<Token<String>>, expectedInvalidChars: Int) {
+		var invalidChars = 0
+		val inputIterator = iter(input)
+		val expectedTokensIterator = expectedTokens.iterator()
+		val lexerIterator = LexerWrapper(lexer) { invalidChars++ }.iterator(inputIterator)
+
+		// check that all the tokens match
+		for (token in lexerIterator) {
+			assertEquals(expectedTokensIterator.next(), token)
+		}
+
+		// check that there aren't any tokens left to check
+		assertFalse(expectedTokensIterator.hasNext())
+
+		// check the number of times onNoMatch was called
+		assertEquals(expectedInvalidChars, invalidChars)
+
+		// check that there aren't any characters left in the input
+		assertFalse(inputIterator.hasNext())
+	}
+}


### PR DESCRIPTION
Closes #9.

The code is still to be improved, especially `LexerWrapper.nextMatch()`.

I think that the need for all the checks, which decrease readability of the code, comes from the fact that I've designed most of the features to be "transparent" (for example, when the lexer finds an ignored token, it tries to return the one after it).
Diverting from this approach would however create the need for highly specialized classes representing different results of the functions (token matched, token ignored, no match, ...). In my eyes, these would be quite annoying to unpack.

I'll try to come up with something.