### PR TITLE
Provide facilities for the lexer to consume multiple different sources of input

### DIFF
--- a/klang/src/main/kotlin/cz/j_jzk/klang/input/IdentifiableInput.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/input/IdentifiableInput.kt
@@ -1,0 +1,6 @@
+package cz.j_jzk.klang.input
+
+data class IdentifiableInput(
+	val id: String,
+	val input: ListIterator<Char>,
+)

--- a/klang/src/main/kotlin/cz/j_jzk/klang/input/IdentifiableInputFactory.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/input/IdentifiableInputFactory.kt
@@ -1,0 +1,16 @@
+package cz.j_jzk.klang.input
+
+import java.io.FileInputStream
+
+/**
+ * An object for creating IdentifiableInputs from common sources, like files.
+ * 
+ * However, this is not the only way to supply data to your lexer. You can use
+ * any class which implements ListIterator, or use InputListIterator to convert
+ * an InputStream to a ListIterator.
+ */
+object InputFactory {
+    public fun fromFile(path: String) = IdentifiableInput(path, InputListIterator(FileInputStream(path)))
+	public fun fromStdin() = IdentifiableInput("STDIN", InputListIterator(System.in))
+	public fun fromString(string: String, id: String) = IdentifiableInput(id, string.toList().listIterator())
+}

--- a/klang/src/main/kotlin/cz/j_jzk/klang/input/InputListIterator.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/input/InputListIterator.kt
@@ -1,0 +1,58 @@
+package cz.j_jzk.klang.input
+
+import java.io.InputStream
+import java.util.LinkedList
+
+class InputListIterator(val input: InputStream): ListIterator<Char> {
+	/* Buffers for moving backwards and forwards.
+	 *
+	 * When moving forwards, the forwardBuffer is filled with characters from
+	 * the input stream as needed.
+	 * 
+	 * It is quite inefficient to pop from one list and push to the other one.
+	 * It would be better to instead have just a node of a doubly linked list
+	 * and use it to shift backward and forward, but the standard implementation
+	 * of linked list in Java doesn't provide a node class.
+	 */
+	private val forwardBuffer = LinkedList<Char>()
+	private val backwardBuffer = LinkedList<Char>()
+	private var index = 0
+
+	override fun hasPrevious() = !backwardBuffer.isEmpty()
+	override fun hasNext(): Boolean {
+		if (!forwardBuffer.isEmpty())
+			return true
+
+		val nextFromInput = input.read()
+		// input.read() returns -1 on end of input
+		if (nextFromInput != -1) {
+			forwardBuffer += nextFromInput.toChar()
+			return true
+		}
+
+		return false
+	}
+	
+	override fun next(): Char {
+		index++
+
+		val value = if (!forwardBuffer.isEmpty())
+				forwardBuffer.removeLast()
+			else
+				input.read().toChar()
+
+		backwardBuffer += value
+		return value
+	}
+
+	override fun previous(): Char {
+		index--
+
+		val value = backwardBuffer.removeLast()
+		forwardBuffer += value
+		return value
+	}
+
+	override fun nextIndex() = index
+	override fun previousIndex() = index - 1
+}

--- a/klang/src/test/kotlin/cz/j_jzk/klang/input/InputListIteratorTest.kt
+++ b/klang/src/test/kotlin/cz/j_jzk/klang/input/InputListIteratorTest.kt
@@ -1,0 +1,116 @@
+package cz.j_jzk.klang.input
+
+import java.io.InputStream
+import java.io.ByteArrayInputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class InputListIteratorTest {
+	@Test fun testForwardIteration() {
+		val iterator = newIterator()
+		for (c in "123456789")
+			assertEquals(c, iterator.next())
+	}
+
+	@Test fun testBackwardIteration() {
+		val iterator = newIterator()
+
+		// skip over all of the chars
+		for (c in "123456789")
+			iterator.next()
+
+		for (c in "987654321")
+			assertEquals(c, iterator.previous())
+	}
+
+	@Test fun testCombinedIteration() {
+		val iterator = newIterator()
+
+		for (c in "12345")
+			assertEquals(c, iterator.next())
+
+		for (c in "5432")
+			assertEquals(c, iterator.previous())
+
+		for (c in "23456789")
+			assertEquals(c, iterator.next())
+
+		for (c in "987654321")
+			assertEquals(c, iterator.previous())
+	}
+
+	@Test fun testHasNext() {
+		val iterator = newIterator()
+		assertTrue(iterator.hasNext())
+
+		for (c in "123456789") {
+			assertTrue(iterator.hasNext())
+			iterator.next()
+		}
+
+		assertFalse(iterator.hasNext())
+		
+		iterator.previous()
+		assertTrue(iterator.hasNext())
+	}
+
+	@Test fun testHasPrevious() {
+		val iterator = newIterator()
+		assertFalse(iterator.hasPrevious())
+
+		iterator.next()
+		assertTrue(iterator.hasPrevious())
+		iterator.previous()
+		assertFalse(iterator.hasPrevious())
+
+		for (c in "123456789") {
+			iterator.next()
+			assertTrue(iterator.hasPrevious())
+		}
+	}
+
+	@Test fun testNextIndex() {
+		val iterator = newIterator()
+		assertEquals(0, iterator.nextIndex())
+		assertEquals(0, iterator.nextIndex())
+
+		iterator.next()
+		assertEquals(1, iterator.nextIndex())
+		iterator.previous()
+		assertEquals(0, iterator.nextIndex())
+	}
+
+	@Test fun testPreviousIndex() {
+		val iterator = newIterator()
+		iterator.next()
+		assertEquals(0, iterator.previousIndex())
+		assertEquals(0, iterator.previousIndex())
+
+		iterator.next()
+		assertEquals(1, iterator.previousIndex())
+		iterator.previous()
+		assertEquals(0, iterator.previousIndex())
+	}
+
+	@Test fun testHasFunctionsDontMutateData() {
+		val iterator = newIterator()
+
+		iterator.hasNext()
+		assertEquals('1', iterator.next())
+		iterator.hasPrevious()
+		assertEquals('2', iterator.next())
+	}
+
+	@Test fun testIndexFunctionsDontMutateData() {
+		val iterator = newIterator()
+
+		iterator.nextIndex()
+		assertEquals('1', iterator.next())
+		iterator.previousIndex()
+		assertEquals('2', iterator.next())
+	}
+
+	private fun newIterator() = InputListIterator(ByteArrayInputStream("123456789".toByteArray()))
+}


### PR DESCRIPTION
Instead of basically a string, the lexer can now consume all sorts of java.io.InputStreams.

The IdentifiableInput is to be used in a future commit for, well, identifying the input source.