### PR TITLE
Decouple ParserWrapper from the LexerIterator

### DIFF
--- a/klang/src/main/kotlin/cz/j_jzk/klang/parse/ParserWrapper.kt
+++ b/klang/src/main/kotlin/cz/j_jzk/klang/parse/ParserWrapper.kt
@@ -4,14 +4,21 @@ import cz.j_jzk.klang.parse.algo.DFA
 import cz.j_jzk.klang.lex.LexerWrapper
 
 /** A utility class to simplify the interop between the lexer and the parser */
-class ParserWrapper<I, D>(val dfa: DFA<D>, private val tokenConversions: Map<I, (String) -> D>) {
+class ParserWrapper<I, D>(val dfa: DFA<D>, val tokenConversions: Map<I, (String) -> D>) {
 	/**
 	 * Parses the tokens from the `input`.
 	 * @param input A stream of tokens, ideally from LexerWrapper.iterator()
 	 * @throws SyntaxError if there were any syntax errors in the input
 	 */
-	fun parse(input: LexerWrapper<I>.LexerIterator): D {
-		val result = dfa.parse(TokenConverter(tokenConversions, input))
+	fun parse(input: LexerWrapper<I>.LexerIterator) = parse(TokenConverter(tokenConversions, input))
+
+	/**
+	 * Parses the AST nodes from `input`.
+	 * @param input A stream of unprocessed AST nodes
+	 * @throws SyntaxError if there were any syntax errors in the input
+	 */
+	fun parse(input: Iterator<ASTNode<D>>): D {
+		val result = dfa.parse(input)
 		if (result is ASTNode.Erroneous)
 			throw SyntaxError()
 		else


### PR DESCRIPTION
Adds the option to use a custom stream of ASTNodes instead of the TokenConverter.

Also makes `tokenConversions` public, because when using the parser builder, there is no way to extract them.
